### PR TITLE
IdentityType

### DIFF
--- a/src/Galaxy.Libra.DapperExtensions.Test/Galaxy.Libra.DapperExtensions.Test.csproj
+++ b/src/Galaxy.Libra.DapperExtensions.Test/Galaxy.Libra.DapperExtensions.Test.csproj
@@ -7,10 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="MySql.Data" Version="8.0.15" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="MySql.Data" Version="8.0.18" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 

--- a/src/Galaxy.Libra.DapperExtensions/DapperImpl/DapperImplementorInsert.cs
+++ b/src/Galaxy.Libra.DapperExtensions/DapperImpl/DapperImplementorInsert.cs
@@ -64,7 +64,24 @@ namespace Galaxy.Libra.DapperExtensions.DapperImpl
                 }
 
                 long identityValue = result.First();
-                int identityInt = Convert.ToInt32(identityValue);
+                dynamic identityInt = 0;
+                switch (identityColumn.IdentityType)
+                {
+                    case IdentityType.Int32:
+                        identityInt = Convert.ToInt32(identityValue);
+                        break;
+                    case IdentityType.UInt32:
+                        identityInt = Convert.ToUInt32(identityValue);
+                        break;
+                    case IdentityType.Int64:
+                        identityInt = Convert.ToInt64(identityValue);
+                        break;
+                    case IdentityType.Int64Unsigned:
+                        identityInt = Convert.ToUInt64(identityValue);
+                        break;
+                    default:
+                        break;
+                }
                 keyValues.Add(identityColumn.Name, identityInt);
                 identityColumn.PropertyInfo.SetValue(entity, identityInt, null);
             }

--- a/src/Galaxy.Libra.DapperExtensions/Galaxy.Libra.DapperExtensions.csproj
+++ b/src/Galaxy.Libra.DapperExtensions/Galaxy.Libra.DapperExtensions.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapper" Version="1.50.7" />
+    <PackageReference Include="Dapper" Version="2.0.30" />
   </ItemGroup>
 
 </Project>

--- a/src/Galaxy.Libra.DapperExtensions/Galaxy.Libra.DapperExtensions.csproj
+++ b/src/Galaxy.Libra.DapperExtensions/Galaxy.Libra.DapperExtensions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <Authors>leeon</Authors>
     <Description>一个轻量的dapper扩展库</Description>
     <Copyright>leeon</Copyright>

--- a/src/Galaxy.Libra.DapperExtensions/Mapper/PropertyMap.cs
+++ b/src/Galaxy.Libra.DapperExtensions/Mapper/PropertyMap.cs
@@ -29,6 +29,9 @@ namespace Galaxy.Libra.DapperExtensions.Mapper
         bool IsAutoIncrement { get; }
 
         KeyType KeyType { get; }
+
+        IdentityType IdentityType { get; }
+
         PropertyInfo PropertyInfo { get; }
     }
 
@@ -60,6 +63,11 @@ namespace Galaxy.Libra.DapperExtensions.Mapper
         /// Gets the key type for the current property.
         /// </summary>
         public KeyType KeyType { get; private set; }
+
+        /// <summary>
+        /// If the KeyType is Identity, used to specified the valued-type.
+        /// </summary>
+        public IdentityType IdentityType { get; private set; }
 
         /// <summary>
         /// Gets the ignore status of the current property. If ignored, the current property will not be included in queries.
@@ -188,6 +196,17 @@ namespace Galaxy.Libra.DapperExtensions.Mapper
         /// <summary>
         /// The property is a key that is not automatically managed.
         /// </summary>
-        Assigned
+        Assigned,
+    }
+
+    public enum IdentityType
+    {
+        Int32,
+
+        UInt32,
+
+        Int64,
+
+        Int64Unsigned,
     }
 }


### PR DESCRIPTION
Add an enum named IdentityType to  specified the valued-type ; 
``` 
    public enum IdentityType
    {
        Int32, 

        UInt32,

        Int64,

        Int64Unsigned,
    }
```

when fetch data from database:

```
            long identityValue = result.First();
            dynamic identityInt = 0;
            switch (identityColumn.IdentityType)
            {
                case IdentityType.Int32:
                    identityInt = Convert.ToInt32(identityValue);
                    break;
                case IdentityType.UInt32:
                    identityInt = Convert.ToUInt32(identityValue);
                    break;
                case IdentityType.Int64:
                    identityInt = Convert.ToInt64(identityValue);
                    break;
                case IdentityType.Int64Unsigned:
                    identityInt = Convert.ToUInt64(identityValue);
                    break;
                default:
                        break;
            }
```
